### PR TITLE
MongoDB-ODM 2: The attribute fieldName is not allowed

### DIFF
--- a/Resources/config/doctrine/AccessToken.mongodb.xml
+++ b/Resources/config/doctrine/AccessToken.mongodb.xml
@@ -5,8 +5,8 @@
                         http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
     <mapped-superclass name="FOS\OAuthServerBundle\Document\AccessToken">
-        <field name="token" fieldName="token" type="string" unique="true" />
-        <field name="expiresAt" fieldName="expiresAt" type="int" nullable="true" />
-        <field name="scope" fieldName="scope" type="string" nullable="true" />
+        <field name="token" field-name="token" type="string" unique="true" />
+        <field name="expiresAt" field-name="expiresAt" type="int" nullable="true" />
+        <field name="scope" field-name="scope" type="string" nullable="true" />
     </mapped-superclass>
 </doctrine-mongo-mapping>

--- a/Resources/config/doctrine/AuthCode.mongodb.xml
+++ b/Resources/config/doctrine/AuthCode.mongodb.xml
@@ -5,9 +5,9 @@
                         http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
     <mapped-superclass name="FOS\OAuthServerBundle\Document\AuthCode">
-        <field name="token" fieldName="token" type="string" unique="true" />
-        <field name="redirectUri" fieldName="redirectUri" type="string" />
-        <field name="expiresAt" fieldName="expiresAt" type="int" nullable="true" />
-        <field name="scope" fieldName="scope" type="string" nullable="true" />
+        <field name="token" field-name="token" type="string" unique="true" />
+        <field name="redirectUri" field-name="redirectUri" type="string" />
+        <field name="expiresAt" field-name="expiresAt" type="int" nullable="true" />
+        <field name="scope" field-name="scope" type="string" nullable="true" />
     </mapped-superclass>
 </doctrine-mongo-mapping>

--- a/Resources/config/doctrine/Client.mongodb.xml
+++ b/Resources/config/doctrine/Client.mongodb.xml
@@ -5,9 +5,9 @@
                         http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
     <mapped-superclass name="FOS\OAuthServerBundle\Document\Client">
-        <field name="randomId" fieldName="randomId" type="string" />
-        <field name="redirectUris" fieldName="redirectUris" type="collection" />
-        <field name="secret" fieldName="secret" type="string" />
-        <field name="allowedGrantTypes" fieldName="allowedGrantTypes" type="collection" />
+        <field name="randomId" field-name="randomId" type="string" />
+        <field name="redirectUris" field-name="redirectUris" type="collection" />
+        <field name="secret" field-name="secret" type="string" />
+        <field name="allowedGrantTypes" field-name="allowedGrantTypes" type="collection" />
     </mapped-superclass>
 </doctrine-mongo-mapping>

--- a/Resources/config/doctrine/RefreshToken.mongodb.xml
+++ b/Resources/config/doctrine/RefreshToken.mongodb.xml
@@ -5,8 +5,8 @@
                         http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
     <mapped-superclass name="FOS\OAuthServerBundle\Document\RefreshToken">
-        <field name="token" fieldName="token" type="string" unique="true" />
-        <field name="expiresAt" fieldName="expiresAt" type="int" nullable="true" />
-        <field name="scope" fieldName="scope" type="string" nullable="true" />
+        <field name="token" field-name="token" type="string" unique="true" />
+        <field name="expiresAt" field-name="expiresAt" type="int" nullable="true" />
+        <field name="scope" field-name="scope" type="string" nullable="true" />
     </mapped-superclass>
 </doctrine-mongo-mapping>

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -303,7 +303,7 @@ class Client extends BaseClient
                     http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
     <document name="Acme\ApiBundle\Document\Client" db="acme" collection="oauthClient" customId="true">
-        <field fieldName="id" id="true" strategy="AUTO" />
+        <field field-name="id" id="true" strategy="AUTO" />
     </document>
 
 </doctrine-mongo-mapping>
@@ -345,7 +345,7 @@ class AuthCode extends BaseAuthCode
                     http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
     <document name="Acme\ApiBundle\Document\AuthCode" db="acme" collection="oauthAuthCode" customId="true">
-        <field fieldName="id" id="true" strategy="AUTO" />
+        <field field-name="id" id="true" strategy="AUTO" />
         <reference-one target-document="Acme\ApiBundle\Document\Client" field="client" />
     </document>
 
@@ -388,7 +388,7 @@ class AccessToken extends BaseAccessToken
                     http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
     <document name="Acme\ApiBundle\Document\AccessToken" db="acme" collection="oauthAccessToken" customId="true">
-        <field fieldName="id" id="true" strategy="AUTO" />
+        <field field-name="id" id="true" strategy="AUTO" />
         <reference-one target-document="Acme\ApiBundle\Document\Client" field="client" />
     </document>
 
@@ -431,7 +431,7 @@ class RefreshToken extends BaseRefreshToken
                     http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
     <document name="Acme\ApiBundle\Document\RefreshToken" db="acme" collection="oauthRefreshToken" customId="true">
-        <field fieldName="id" id="true" strategy="AUTO" />
+        <field field-name="id" id="true" strategy="AUTO" />
         <reference-one target-document="Acme\ApiBundle\Document\Client" field="client" />
     </document>
 


### PR DESCRIPTION
We are on the way to update MongoDB ODM to 2.0, and some xml syntax changed :

> The mapping file akeneo/oauth-server-bundle/Resources/config/doctrine/RefreshToken.mongodb.xml is invalid:                      
Line 8:0: Element '{http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping}field', attribute 'fieldName': The attribute 'fieldName' is not allowed. 

(the new one is compatible with version 1.0)

(I didn't touch couchdb, I don't know if the same thing shoufd be done too ?)